### PR TITLE
feat: making Hive mockable in HiveCacheStore

### DIFF
--- a/dio_cache_interceptor_hive_store/lib/src/store/dio_cache_interceptor_hive_store.dart
+++ b/dio_cache_interceptor_hive_store/lib/src/store/dio_cache_interceptor_hive_store.dart
@@ -6,31 +6,39 @@ import 'package:hive_ce/hive.dart';
 class HiveCacheStore extends CacheStore {
   // Cache box name
   final String hiveBoxName;
+
   // Optional cipher to use directly with Hive
   final HiveCipher? encryptionCipher;
+
+  /// The Hive instance to use.
+  final HiveInterface hive;
 
   LazyBox<CacheResponse>? _box;
 
   /// Initialize cache store by giving Hive a home directory.
   /// [directory] can be null only on web platform or if you already use Hive
   /// in your app.
+  ///
+  /// [hiveInterface] is the Hive instance to use. Mostly used for testing.
+  /// If not provided, the default [Hive] instance will be used.
   HiveCacheStore(
     String? directory, {
     this.hiveBoxName = 'dio_cache',
     this.encryptionCipher,
-  }) {
+    HiveInterface? hiveInterface,
+  }) : hive = hiveInterface ?? Hive {
     if (directory != null) {
-      Hive.init(directory);
+      hive.init(directory);
     }
 
-    if (!Hive.isAdapterRegistered(_CacheResponseAdapter._typeId)) {
-      Hive.registerAdapter(_CacheResponseAdapter());
+    if (!hive.isAdapterRegistered(_CacheResponseAdapter._typeId)) {
+      hive.registerAdapter(_CacheResponseAdapter());
     }
-    if (!Hive.isAdapterRegistered(_CacheControlAdapter._typeId)) {
-      Hive.registerAdapter(_CacheControlAdapter());
+    if (!hive.isAdapterRegistered(_CacheControlAdapter._typeId)) {
+      hive.registerAdapter(_CacheControlAdapter());
     }
-    if (!Hive.isAdapterRegistered(_CachePriorityAdapter._typeId)) {
-      Hive.registerAdapter(_CachePriorityAdapter());
+    if (!hive.isAdapterRegistered(_CachePriorityAdapter._typeId)) {
+      hive.registerAdapter(_CachePriorityAdapter());
     }
 
     clean(staleOnly: true);
@@ -140,7 +148,7 @@ class HiveCacheStore extends CacheStore {
   }
 
   Future<LazyBox<CacheResponse>> _openBox() async {
-    _box ??= await Hive.openLazyBox<CacheResponse>(
+    _box ??= await hive.openLazyBox<CacheResponse>(
       hiveBoxName,
       encryptionCipher: encryptionCipher,
     );


### PR DESCRIPTION
## Changes

- Adding an optional parameter "hiveInterface" in HiveCacheStore constructor to pass the HiveInterface that will used by the Store. (default is Hive)
- Migrating all Hive calls to use the new class "hive" attribute.

This allow passing a mock Hive interface and allow more easily tests implementation.

Risks: 2/5 (Main constructors has been modifying by **adding** optional code)