### PR TITLE
fix: Allow optional whitespace in header values

### DIFF
--- a/http_cache_core/lib/src/model/cache/cache_control.dart
+++ b/http_cache_core/lib/src/model/cache/cache_control.dart
@@ -110,6 +110,7 @@ class CacheControl {
           other.add(attribute);
         }
       }
+      scanner.scan(whitespace);
     }
 
     headerValues ??= [];

--- a/http_cache_core/test/cache_control_test.dart
+++ b/http_cache_core/test/cache_control_test.dart
@@ -40,6 +40,29 @@ void main() {
     expect(cacheControl1, equals(cacheControl3));
   });
 
+  test('headers with and without optional whitespace', () {
+    final cacheControl1 = CacheControl(
+      maxAge: 1,
+      noCache: true,
+      noStore: true,
+      other: ['unknown', 'unknown2=2'],
+      privacy: 'public',
+      maxStale: 2,
+      minFresh: 3,
+      mustRevalidate: true,
+    );
+
+    final cacheControl2 = CacheControl.fromHeader([
+      'max-age=1 , no-store,  no-cache, public,unknown , unknown2=2 , max-stale=2,min-fresh=3,must-revalidate',
+    ]);
+
+    expect(cacheControl1, equals(cacheControl2));
+
+    // Redo test with toHeader()
+    final cacheControl3 = CacheControl.fromHeader([cacheControl2.toHeader()]);
+    expect(cacheControl1, equals(cacheControl3));
+  });
+
   test('headers splitted', () {
     final cacheControl1 = CacheControl(
       maxAge: 1,


### PR DESCRIPTION
Optional whitespace in the CacheControl header can also occur before the separating comma. Without this fix, request would fail with a FormatException.

We observed this in production:
```
FormatException: Error on line 1, column 14: expected no more input.
  ╷
1 │ max-age=17748 , stale-while-revalidate=604800, stale-if-error=604800
  │              ^
```